### PR TITLE
Fix compilation errors on mingw

### DIFF
--- a/src/core/rps_core.hpp
+++ b/src/core/rps_core.hpp
@@ -15,12 +15,14 @@
 #include <cstdarg>
 #include <cstdlib>
 #include <cstring>
+#include <cstdio>
 #include <climits>
 
 #include <tuple>
 #include <memory>
 #include <algorithm>
 #include <type_traits>
+#include <vector>
 
 #ifdef RPS_HAS_INTRIN_H
 #include <intrin.h>

--- a/src/core/rps_device.cpp
+++ b/src/core/rps_device.cpp
@@ -12,7 +12,7 @@ namespace rps
 {
     void* rpsDefaultMalloc(void* pContext, size_t size, size_t alignment)
     {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
         return _aligned_malloc(size, alignment);
 #else
         return aligned_alloc(alignment, rpsAlignUp(size, alignment));
@@ -21,7 +21,7 @@ namespace rps
 
     void rpsDefaultFree(void* pContext, void* ptr)
     {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
         return _aligned_free(ptr);
 #else
         return free(ptr);
@@ -65,7 +65,7 @@ namespace rps
 
     void* rpsDefaultRealloc(void* pContext, void* pOldBuffer, size_t oldSize, size_t newSize, size_t alignment)
     {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
         return _aligned_realloc(pOldBuffer, newSize, alignment);
 #else
         return rpsFallbackRealloc(&s_DefaultAllocator, pOldBuffer, oldSize, newSize, alignment);

--- a/tests/utils/rps_test_common.h
+++ b/tests/utils/rps_test_common.h
@@ -50,7 +50,7 @@ static int g_NumMallocs = 0;
 static void* CountedMalloc(void* pContext, size_t size, size_t alignment)
 {
     g_NumMallocs++;
-#if _MSC_VER
+#if _MSC_VER || __MINGW32__
     return _aligned_malloc(size, alignment);
 #else
     const size_t alignedSize = alignment ? (size + (alignment - 1)) & ~(alignment - 1) : size;

--- a/tools/app_framework/afx_win32.h
+++ b/tools/app_framework/afx_win32.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 


### PR DESCRIPTION
I made a few fixes to make RenderPipelineShaders compile on Mingw. 
Before it only worked on MSVC :)