### PR TITLE
Add support for dynamic vulkan loaders

### DIFF
--- a/include/rps/runtime/vk/rps_vk_runtime.h
+++ b/include/rps/runtime/vk/rps_vk_runtime.h
@@ -11,6 +11,10 @@
 #include "rps/core/rps_api.h"
 #include "rps/runtime/common/rps_runtime.h"
 
+#if defined(RPS_VK_NO_PROTOTYPES) || defined(RPS_VK_DYNAMIC_VULKAN_FUNCTIONS)
+#define VK_NO_PROTOTYPES
+#endif
+
 #include <vulkan/vulkan.h>
 
 /// @addtogroup RpsVKRuntimeDevice
@@ -29,6 +33,42 @@ typedef enum RpsVKRuntimeFlagBits
 /// @brief Bitmask type for <c><i>RpsVKRuntimeFlagBits</i></c>
 typedef uint32_t RpsVKRuntimeFlags;
 
+/// @brief Pointers to some Vulkan functions - a subset used by the library.
+typedef struct RpsVKFunctions {
+    PFN_vkGetPhysicalDeviceProperties vkGetPhysicalDeviceProperties;
+    PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties;
+    PFN_vkCreateImage vkCreateImage;
+    PFN_vkDestroyImage vkDestroyImage;
+    PFN_vkBindImageMemory vkBindImageMemory;
+    PFN_vkGetImageMemoryRequirements vkGetImageMemoryRequirements;
+    PFN_vkCreateBuffer vkCreateBuffer;
+    PFN_vkDestroyBuffer vkDestroyBuffer;
+    PFN_vkBindBufferMemory vkBindBufferMemory;
+    PFN_vkGetBufferMemoryRequirements vkGetBufferMemoryRequirements;
+    PFN_vkCreateFramebuffer vkCreateFramebuffer;
+    PFN_vkDestroyFramebuffer vkDestroyFramebuffer;
+    PFN_vkCreateRenderPass vkCreateRenderPass;
+    PFN_vkDestroyRenderPass vkDestroyRenderPass;
+    PFN_vkCreateBufferView vkCreateBufferView;
+    PFN_vkDestroyBufferView vkDestroyBufferView;
+    PFN_vkCreateImageView vkCreateImageView;
+    PFN_vkDestroyImageView vkDestroyImageView;
+    PFN_vkAllocateMemory vkAllocateMemory;
+    PFN_vkFreeMemory vkFreeMemory;
+    PFN_vkCmdBeginRenderPass vkCmdBeginRenderPass;
+    PFN_vkCmdEndRenderPass vkCmdEndRenderPass;
+    PFN_vkCmdSetViewport vkCmdSetViewport;
+    PFN_vkCmdSetScissor vkCmdSetScissor;
+    PFN_vkCmdPipelineBarrier vkCmdPipelineBarrier;
+    PFN_vkCmdClearColorImage vkCmdClearColorImage;
+    PFN_vkCmdClearDepthStencilImage vkCmdClearDepthStencilImage;
+    PFN_vkCmdCopyImage vkCmdCopyImage;
+    PFN_vkCmdCopyBuffer vkCmdCopyBuffer;
+    PFN_vkCmdCopyImageToBuffer vkCmdCopyImageToBuffer;
+    PFN_vkCmdCopyBufferToImage vkCmdCopyBufferToImage;
+    PFN_vkCmdResolveImage vkCmdResolveImage;
+} RpsVKFunctions;
+
 /// @brief Creation parameters for an RPS device with a Vulkan backend.
 typedef struct RpsVKRuntimeDeviceCreateInfo
 {
@@ -36,6 +76,8 @@ typedef struct RpsVKRuntimeDeviceCreateInfo
                                                            ///  Passing NULL uses default parameters instead.
     const RpsRuntimeDeviceCreateInfo* pRuntimeCreateInfo;  ///< Pointer to general RPS runtime creation info. Passing
                                                            ///  NULL uses default parameters instead.
+    const RpsVKFunctions* pVulkanFunctions;                ///< Pointer to the Vulkan functions used by the library.
+                                                           ///  If RPS_VK_STATIC_VULKAN_FUNCTIONS is not defined, pFunctions must not be NULL.
     VkDevice hVkDevice;                                    ///< Handle to the VK device to use for the runtime. Must not
                                                            ///  be VK_NULL_HANDLE.
     VkPhysicalDevice hVkPhysicalDevice;                    ///< Handle to the VK physical device to use for the runtime.

--- a/src/runtime/vk/rps_vk_built_in_nodes.cpp
+++ b/src/runtime/vk/rps_vk_built_in_nodes.cpp
@@ -38,6 +38,9 @@ namespace rps
     {
         VkCommandBuffer hCmdBuf = rpsVKCommandBufferFromHandle(pContext->hCommandBuffer);
 
+        auto* pBackend = rps::VKRuntimeBackend::Get(pContext);
+        auto* pRuntimeDevice = RuntimeDevice::Get<VKRuntimeDevice>(pBackend->GetRenderGraph().GetDevice());
+
         RPS_ASSERT(pContext->numArgs > 1);
 
         static_assert(sizeof(RpsClearValue) == sizeof(VkClearColorValue),
@@ -63,7 +66,7 @@ namespace rps
         vkRange.baseArrayLayer          = pImageView->subresourceRange.baseArrayLayer;
         vkRange.layerCount              = pImageView->subresourceRange.arrayLayers;
 
-        vkCmdClearColorImage(hCmdBuf, hImg, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, pClearValue, 1, &vkRange);
+        pRuntimeDevice->GetFunctions().vkCmdClearColorImage(hCmdBuf, hImg, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, pClearValue, 1, &vkRange);
     }
 
     void VKBuiltInClearColorRegions(const RpsCmdCallbackContext* pContext)
@@ -79,6 +82,9 @@ namespace rps
     void VKBuiltInClearDepthStencil(const RpsCmdCallbackContext* pContext)
     {
         VkCommandBuffer hCmdBuf = rpsVKCommandBufferFromHandle(pContext->hCommandBuffer);
+
+        auto* pBackend = rps::VKRuntimeBackend::Get(pContext);
+        auto* pRuntimeDevice = RuntimeDevice::Get<VKRuntimeDevice>(pBackend->GetRenderGraph().GetDevice());
 
         RPS_ASSERT(pContext->numArgs > 1);
 
@@ -105,7 +111,7 @@ namespace rps
         vkRange.baseArrayLayer          = pImageView->subresourceRange.baseArrayLayer;
         vkRange.layerCount              = pImageView->subresourceRange.arrayLayers;
 
-        vkCmdClearDepthStencilImage(hCmdBuf, hImg, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearValue, 1, &vkRange);
+        pRuntimeDevice->GetFunctions().vkCmdClearDepthStencilImage(hCmdBuf, hImg, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearValue, 1, &vkRange);
     }
 
     void VKBuiltInClearDepthStencilRegions(const RpsCmdCallbackContext* pContext)
@@ -130,7 +136,6 @@ namespace rps
         VkCommandBuffer hCmdBuf = rpsVKCommandBufferFromHandle(pContext->hCommandBuffer);
 
         auto* pBackend = rps::VKRuntimeBackend::Get(pContext);
-
         auto* pRuntimeDevice = RuntimeDevice::Get<VKRuntimeDevice>(pBackend->GetRenderGraph().GetDevice());
 
         RPS_ASSERT(pContext->numArgs == 5);
@@ -225,7 +230,7 @@ namespace rps
         const VkImage hDstResource = rpsVKImageFromHandle(pDstResource->hRuntimeResource);
         const VkImage hSrcResource = rpsVKImageFromHandle(pSrcResource->hRuntimeResource);
 
-        vkCmdCopyImage(hCmdBuf,
+        pRuntimeDevice->GetFunctions().vkCmdCopyImage(hCmdBuf,
                        hSrcResource,
                        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                        hDstResource,
@@ -239,6 +244,7 @@ namespace rps
         VkCommandBuffer hCmdBuf = rpsVKCommandBufferFromHandle(pContext->hCommandBuffer);
 
         auto* pBackend = rps::VKRuntimeBackend::Get(pContext);
+        auto* pRuntimeDevice = RuntimeDevice::Get<VKRuntimeDevice>(pBackend->GetRenderGraph().GetDevice());
 
         const ResourceInstance *pDstResource, *pSrcResource;
         RPS_V_REPORT_AND_RETURN(pContext,
@@ -263,7 +269,7 @@ namespace rps
         copyInfo.dstOffset = dstOffset;
         copyInfo.size      = (copySize != UINT64_MAX) ? copySize : srcTotalSize;
 
-        vkCmdCopyBuffer(hCmdBuf, srcBuffer, dstBuffer, 1, &copyInfo);
+        pRuntimeDevice->GetFunctions().vkCmdCopyBuffer(hCmdBuf, srcBuffer, dstBuffer, 1, &copyInfo);
     }
 
     static constexpr bool TextureToBuffer = true;
@@ -337,11 +343,11 @@ namespace rps
 
         if (SourceIsTexture)
         {
-            vkCmdCopyImageToBuffer(hCmdBuf, imageHdl, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, bufferHdl, 1, &copyInfos);
+            pRuntimeDevice->GetFunctions().vkCmdCopyImageToBuffer(hCmdBuf, imageHdl, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, bufferHdl, 1, &copyInfos);
         }
         else
         {
-            vkCmdCopyBufferToImage(hCmdBuf, bufferHdl, imageHdl, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyInfos);
+            pRuntimeDevice->GetFunctions().vkCmdCopyBufferToImage(hCmdBuf, bufferHdl, imageHdl, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyInfos);
         }
     }
 
@@ -399,7 +405,6 @@ namespace rps
         VkCommandBuffer hCmdBuf = rpsVKCommandBufferFromHandle(pContext->hCommandBuffer);
 
         auto* pBackend = rps::VKRuntimeBackend::Get(pContext);
-
         auto* pRuntimeDevice = RuntimeDevice::Get<VKRuntimeDevice>(pBackend->GetRenderGraph().GetDevice());
 
         RPS_ASSERT(pContext->numArgs == 6);
@@ -484,7 +489,7 @@ namespace rps
         const VkImage hDstResource = rpsVKImageFromHandle(pDstResource->hRuntimeResource);
         const VkImage hSrcResource = rpsVKImageFromHandle(pSrcResource->hRuntimeResource);
 
-        vkCmdResolveImage(hCmdBuf,
+        pRuntimeDevice->GetFunctions().vkCmdResolveImage(hCmdBuf,
                           hSrcResource,
                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                           hDstResource,

--- a/src/runtime/vk/rps_vk_runtime_backend.hpp
+++ b/src/runtime/vk/rps_vk_runtime_backend.hpp
@@ -199,36 +199,36 @@ namespace rps
                 pendingBuffers.reset(&arena);
             }
 
-            void DestroyDeviceResources(VkDevice hDevice)
+            void DestroyDeviceResources(VkDevice hDevice, const RpsVKFunctions& functions)
             {
                 for (VkFramebuffer fb : frameBuffers)
                 {
-                    vkDestroyFramebuffer(hDevice, fb, nullptr);
+                    functions.vkDestroyFramebuffer(hDevice, fb, nullptr);
                 }
 
                 for (VkRenderPass rp : renderPasses)
                 {
-                    vkDestroyRenderPass(hDevice, rp, nullptr);
+                    functions.vkDestroyRenderPass(hDevice, rp, nullptr);
                 }
 
                 for (VkBufferView bufView : bufferViews)
                 {
-                    vkDestroyBufferView(hDevice, bufView, nullptr);
+                    functions.vkDestroyBufferView(hDevice, bufView, nullptr);
                 }
 
                 for (VkImageView imgView : imageViews)
                 {
-                    vkDestroyImageView(hDevice, imgView, nullptr);
+                    functions.vkDestroyImageView(hDevice, imgView, nullptr);
                 }
 
                 for (VkBuffer buf : pendingBuffers)
                 {
-                    vkDestroyBuffer(hDevice, buf, nullptr);
+                    functions.vkDestroyBuffer(hDevice, buf, nullptr);
                 }
 
                 for (VkImage img : pendingImages)
                 {
-                    vkDestroyImage(hDevice, img, nullptr);
+                    functions.vkDestroyImage(hDevice, img, nullptr);
                 }
 
                 pendingImages.clear();

--- a/src/runtime/vk/rps_vk_runtime_device.cpp
+++ b/src/runtime/vk/rps_vk_runtime_device.cpp
@@ -27,12 +27,49 @@ namespace rps
         , m_physicalDevice(pCreateInfo->hVkPhysicalDevice)
         , m_flags(pCreateInfo->flags)
     {
+#ifndef RPS_VK_DYNAMIC_VULKAN_FUNCTIONS
+        m_functions.vkGetPhysicalDeviceProperties = vkGetPhysicalDeviceProperties;
+        m_functions.vkGetPhysicalDeviceMemoryProperties = vkGetPhysicalDeviceMemoryProperties;
+        m_functions.vkCreateImage = vkCreateImage;
+        m_functions.vkDestroyImage = vkDestroyImage;
+        m_functions.vkBindImageMemory = vkBindImageMemory;
+        m_functions.vkGetImageMemoryRequirements = vkGetImageMemoryRequirements;
+        m_functions.vkCreateBuffer = vkCreateBuffer;
+        m_functions.vkDestroyBuffer = vkDestroyBuffer;
+        m_functions.vkBindBufferMemory = vkBindBufferMemory;
+        m_functions.vkGetBufferMemoryRequirements = vkGetBufferMemoryRequirements;
+        m_functions.vkCreateFramebuffer = vkCreateFramebuffer;
+        m_functions.vkDestroyFramebuffer = vkDestroyFramebuffer;
+        m_functions.vkCreateRenderPass = vkCreateRenderPass;
+        m_functions.vkDestroyRenderPass = vkDestroyRenderPass;
+        m_functions.vkCreateBufferView = vkCreateBufferView;
+        m_functions.vkDestroyBufferView = vkDestroyBufferView;
+        m_functions.vkCreateImageView = vkCreateImageView;
+        m_functions.vkDestroyImageView = vkDestroyImageView;
+        m_functions.vkAllocateMemory = vkAllocateMemory;
+        m_functions.vkFreeMemory = vkFreeMemory;
+        m_functions.vkCmdBeginRenderPass = vkCmdBeginRenderPass;
+        m_functions.vkCmdEndRenderPass = vkCmdEndRenderPass;
+        m_functions.vkCmdSetViewport = vkCmdSetViewport;
+        m_functions.vkCmdSetScissor = vkCmdSetScissor;
+        m_functions.vkCmdPipelineBarrier = vkCmdPipelineBarrier;
+        m_functions.vkCmdClearColorImage = vkCmdClearColorImage;
+        m_functions.vkCmdClearDepthStencilImage = vkCmdClearDepthStencilImage;
+        m_functions.vkCmdCopyImage = vkCmdCopyImage;
+        m_functions.vkCmdCopyBuffer = vkCmdCopyBuffer;
+        m_functions.vkCmdCopyImageToBuffer = vkCmdCopyImageToBuffer;
+        m_functions.vkCmdCopyBufferToImage = vkCmdCopyBufferToImage;
+        m_functions.vkCmdResolveImage = vkCmdResolveImage;
+#else
+        RPS_ASSERT(pCreateInfo->pVulkanFunctions);
+        m_functions = *pCreateInfo->pVulkanFunctions;
+#endif
     }
 
     RpsResult VKRuntimeDevice::Init()
     {
-        vkGetPhysicalDeviceProperties(m_physicalDevice, &m_deviceProperties);
-        vkGetPhysicalDeviceMemoryProperties(m_physicalDevice, &m_deviceMemoryProperties);
+        m_functions.vkGetPhysicalDeviceProperties(m_physicalDevice, &m_deviceProperties);
+        m_functions.vkGetPhysicalDeviceMemoryProperties(m_physicalDevice, &m_deviceMemoryProperties);
 
         static_assert(VK_MAX_MEMORY_TYPES <= 32, "Bitwidth of m_hostVisibleMemoryTypeMask needs extending.");
 
@@ -311,10 +348,10 @@ namespace rps
                 GetVkImageCreateInfo(imgCI, resInstance);
 
                 VkImage hImage;
-                RPS_V_RETURN(VkResultToRps(vkCreateImage(m_device, &imgCI, nullptr, &hImage)));
+                RPS_V_RETURN(VkResultToRps(m_functions.vkCreateImage(m_device, &imgCI, nullptr, &hImage)));
 
                 allocInfo.hRuntimeResource = ToHandle(hImage);
-                vkGetImageMemoryRequirements(m_device, hImage, &allocInfo.memoryRequirements);
+                m_functions.vkGetImageMemoryRequirements(m_device, hImage, &allocInfo.memoryRequirements);
             }
             else if (resInstance.desc.IsBuffer())
             {
@@ -322,10 +359,10 @@ namespace rps
                 GetVkBufferCreateInfo(bufCI, resInstance);
 
                 VkBuffer hBuffer;
-                RPS_V_RETURN(VkResultToRps(vkCreateBuffer(m_device, &bufCI, nullptr, &hBuffer)));
+                RPS_V_RETURN(VkResultToRps(m_functions.vkCreateBuffer(m_device, &bufCI, nullptr, &hBuffer)));
 
                 allocInfo.hRuntimeResource = ToHandle(hBuffer);
-                vkGetBufferMemoryRequirements(m_device, hBuffer, &allocInfo.memoryRequirements);
+                m_functions.vkGetBufferMemoryRequirements(m_device, hBuffer, &allocInfo.memoryRequirements);
             }
         }
 

--- a/src/runtime/vk/rps_vk_runtime_device.hpp
+++ b/src/runtime/vk/rps_vk_runtime_device.hpp
@@ -55,6 +55,11 @@ namespace rps
             return m_physicalDevice;
         }
 
+        const RpsVKFunctions& GetFunctions() const
+        {
+            return m_functions;
+        }
+
         const VkPhysicalDeviceProperties& GetPhysicalDeviceProperties() const
         {
             return m_deviceProperties;
@@ -81,6 +86,7 @@ namespace rps
     private:
         VkDevice         m_device         = VK_NULL_HANDLE;
         VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
+        RpsVKFunctions    m_functions      = {};
 
         RpsVKRuntimeFlags m_flags = RPS_VK_RUNTIME_FLAG_NONE;
 


### PR DESCRIPTION
Hey,
Many applications do not link directly to `vulkan-1.lib`. Instead, they load the Vulkan entry points dynamically. In this PR, I added support for dynamic vulkan functions to RPS.

The macro `RPS_VK_DYNAMIC_VULKAN_FUNCTIONS` enables loading the vulkan functions from a structure called `RpsVKFunctions` provided in `RpsVKRuntimeDeviceCreateInfo` instead of using the statically linked functions. The structure `RpsVKFunctions` contains all required vulkan functions used by the library.

Since I'm creating a rust wrapper for RPS, it is required to import the vulkan functions from the `Ash` wrapper.
See https://github.com/projectkml/render-pipeline-shaders-rs