### PR TITLE
Integration with latest ImGui (>1.89.3)

### DIFF
--- a/tools/rps_visualizer/src/rps_visualizer_util.hpp
+++ b/tools/rps_visualizer/src/rps_visualizer_util.hpp
@@ -13,8 +13,8 @@
 #include <string>
 #include <inttypes.h>
 
-#include "imgui.h"
 #define IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui.h"
 #include "imgui_internal.h"
 
 #include "core/rps_util.hpp"


### PR DESCRIPTION
Cosmetics, this allows to integrate the latest ImGui (1.89.4 at the moment) by moving `#define IMGUI_DEFINE_MATH_OPERATORS` before including `imgui.h` as requested (default math operators were moved out from `imgui_internal.h`).

This req addresses [#21](https://github.com/GPUOpen-LibrariesAndSDKs/RenderPipelineShaders/issues/21)