### PR TITLE
Cleanup the same filename stem for `rps_rpsl_host`

### DIFF
--- a/src/runtime/common/rps_rpsl_host.hpp
+++ b/src/runtime/common/rps_rpsl_host.hpp
@@ -14,7 +14,7 @@
 #include "core/rps_core.hpp"
 #include "core/rps_persistent_index_generator.hpp"
 #include "runtime/common/rps_cmd_buf.hpp"
-#include "runtime/common/rps_rpsl_host.h"
+#include "runtime/common/rps_rpsl_host_callbacks.h"
 
 namespace rps
 {

--- a/src/runtime/common/rps_rpsl_host_callbacks.c
+++ b/src/runtime/common/rps_rpsl_host_callbacks.c
@@ -10,7 +10,7 @@
 
 #include "rps/core/rps_api.h"
 
-#include "runtime/common/rps_rpsl_host.h"
+#include "runtime/common/rps_rpsl_host_callbacks.h"
 
 extern RpsResult RpslHostBlockMarker(uint32_t markerType,
                                      uint32_t blockIndex,

--- a/src/runtime/common/rps_rpsl_host_callbacks.h
+++ b/src/runtime/common/rps_rpsl_host_callbacks.h
@@ -5,8 +5,8 @@
 //
 // See file LICENSE.RTF for full license details.
 
-#ifndef _RPS_RPSL_HOST_H_
-#define _RPS_RPSL_HOST_H_
+#ifndef _RPS_RPSL_HOST_CALLBACKS_H_
+#define _RPS_RPSL_HOST_CALLBACKS_H_
 
 /// @brief Bitflags for the type of entry calls.
 enum RpslEntryCallFlagBits


### PR DESCRIPTION
Lack of this leads to problem with other than CMake build-systems where obj-outputs are overwritten due to same filename stem for `rps_rpsl_host` whithin same directory.

Problem example https://github.com/ubisoft/Sharpmake/issues/264

This req addresses https://github.com/GPUOpen-LibrariesAndSDKs/RenderPipelineShaders/issues/24