### PR TITLE
Fix Hello Triangle Breathing example not working properly

### DIFF
--- a/examples/hello_triangle.cpp
+++ b/examples/hello_triangle.cpp
@@ -221,8 +221,8 @@ protected:
             if (c_bBreathing)
             {
                 argDataCount = 2;
-                time = float(RpsAfxCpuTimer::SecondsSinceEpoch().count());
-                argData[1] = &time;
+                time         = float(RpsAfxCpuTimer::SecondsSinceEpoch().count());
+                argData[1]   = &time;
             }
 
             // RpsAfx always waits for presentation before rendering to a swapchain image again,

--- a/examples/hello_triangle.cpp
+++ b/examples/hello_triangle.cpp
@@ -216,12 +216,13 @@ protected:
             const RpsRuntimeResource* argResources[2] = {backBufferResources};
 
             uint32_t argDataCount = 1;
+            float time;
 
             if (c_bBreathing)
             {
                 argDataCount = 2;
-                float time   = float(RpsAfxCpuTimer::SecondsSinceEpoch().count());
-                argData[1]   = &time;
+                time = float(RpsAfxCpuTimer::SecondsSinceEpoch().count());
+                argData[1] = &time;
             }
 
             // RpsAfx always waits for presentation before rendering to a swapchain image again,


### PR DESCRIPTION
`time` is declared on the stack, but was accessed through a pointer after being unscoped when calling `rpsRenderGraphUpdate()`.
It resulted in receiving an invalid value in `DrawTriangleBreathingCb`, breaking the demo.

This PR fixes the issue by moving the local variable declaration to the same scope as `rpsRenderGraphUpdate()`.