### PR TITLE
Fix Builder test update info

### DIFF
--- a/tests/console/test_builder.cpp
+++ b/tests/console/test_builder.cpp
@@ -158,7 +158,7 @@ TEST_CASE("BuildGraphUsingCApiCommon")
     graphParams[0].typeInfo         = rpsTypeInfoInitFromType(RpsResourceDesc);
     graphParams[0].flags            = RPS_PARAMETER_FLAG_RESOURCE_BIT;
     graphParams[0].name             = "backBuffer";
-    graphParams[1].typeInfo         = rpsTypeInfoInitFromType(void*);
+    graphParams[1].typeInfo         = rpsTypeInfoInitFromType(PrivateUpdateInfo);
     graphParams[1].name             = "pUserContext";
 
     RpsRenderGraphSignatureDesc entryInfo = {0};


### PR DESCRIPTION
In `test_builder`, we use the following structure to pass graph info:
```cpp
struct PrivateUpdateInfo
{
    uint32_t width;
    uint32_t height;
    RpsBool  bUseOffscreenRT;
    RpsBool  bUseMSAA;
};
```

However we were using `rpsTypeInfoInitFromType(void*)` to pass param type information to the graph. This resulted in the graph param size being set to 8 bytes (the size of a pointer on an x64 machine), while the actual data in 16 bytes long. 
This meant that the struct data was only partially copied, and that the values of booleans fetched in the builder callback were undefined.

This PR fixes the issue by passing the correct type in the param information field.