### PR TITLE
Fix some assertions and VK validation errors with the latest SDK v1.3.275.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ else ( )
 endif ( )
 
 set( NugetPackagesRoot "${CMAKE_BINARY_DIR}/rps_nuget_packages" )
-set( DXAgilitySDK_VERSION_STRING "1.608.3" )
-set( DXAgilitySDK_VERSION 608 ) # to set D3D12SDKVersion
+set( DXAgilitySDK_VERSION_STRING "1.613.0" )
+set( DXAgilitySDK_VERSION 613 ) # to set D3D12SDKVersion
 set( DXAgilitySDK_INSTALL_DIR "${NugetPackagesRoot}/DXAgilitySDK.${DXAgilitySDK_VERSION_STRING}" )
 set( RpsDXAgilitySDK_DIR "${DXAgilitySDK_INSTALL_DIR}" CACHE STRING "DX12 Agility SDK directory" )
 

--- a/src/runtime/common/phases/rps_pre_process.hpp
+++ b/src/runtime/common/phases/rps_pre_process.hpp
@@ -281,6 +281,7 @@ namespace rps
                     pResInstance->InvalidateRuntimeResource(pRuntimeBackend);
                 }
                 pResInstance->isPendingInit = false;
+                pResInstance->isAccessed    = false;
 
                 pResInstance->SetInitialAccess(AccessAttr{});
 
@@ -356,6 +357,7 @@ namespace rps
 
                 ResourceInstance tempResInstCopy = parentResInstance;
                 tempResInstCopy.isTemporalSlice  = true;
+                tempResInstCopy.isAccessed       = false;
 
                 if (!bIsParentParamResource)
                 {
@@ -404,6 +406,11 @@ namespace rps
 
                 temporalSlice.SetInitialAccess(AccessAttr{});
                 temporalSlice.finalAccesses = {};
+
+                for (uint32_t iTemporalSlice = 0; iTemporalSlice < numTemporalLayers; iTemporalSlice++)
+                {
+                    resInstances[parentResInstance.temporalLayerOffset + iTemporalSlice].isAccessed = false;
+                }
             }
 
             return RPS_OK;
@@ -838,6 +845,8 @@ namespace rps
             RPS_ASSERT(paramAccessInfo.access.accessFlags != RPS_ACCESS_UNKNOWN);
 
             accessInfo.resourceId = resInstanceId;
+
+            resInstance.isAccessed = true;
 
             bool bPendingRecreate = false;
 

--- a/src/runtime/common/phases/rps_schedule_print.hpp
+++ b/src/runtime/common/phases/rps_schedule_print.hpp
@@ -90,7 +90,7 @@ namespace rps
                     printer(" ]");
                 }
 
-                for (uint32_t iCmd = batchInfo.waitFencesBegin, cmdEnd = batchInfo.waitFencesBegin + batchInfo.numCmds;
+                for (uint32_t iCmd = batchInfo.cmdBegin, cmdEnd = batchInfo.cmdBegin + batchInfo.numCmds;
                      iCmd < cmdEnd;
                      iCmd++)
                 {

--- a/src/runtime/common/rps_render_graph.cpp
+++ b/src/runtime/common/rps_render_graph.cpp
@@ -34,10 +34,9 @@ namespace rps
 
         if (pCreateInfo)
         {
-            (*ppRenderGraph)->OnInit(renderGraphCreateInfo);
+            RPS_V_RETURN((*ppRenderGraph)->OnInit(renderGraphCreateInfo));
         }
 
-        
         if (pRuntimeDevice)
         {
             if ((*ppRenderGraph)->m_createInfo.numPhases == 0)

--- a/src/runtime/common/rps_render_graph.hpp
+++ b/src/runtime/common/rps_render_graph.hpp
@@ -65,6 +65,7 @@ namespace rps
         bool                    isAliased : 1;
         bool                    isPendingCreate : 1;
         bool                    isPendingInit : 1;
+        bool                    isAccessed : 1;
         bool                    isMutableFormat : 1;
         bool                    bBufferFormattedWrite : 1;
         bool                    bBufferFormattedRead : 1;

--- a/src/runtime/common/rps_render_graph_signature.hpp
+++ b/src/runtime/common/rps_render_graph_signature.hpp
@@ -403,9 +403,8 @@ namespace rps
 
         uint32_t FindNodeDeclIndexByName(const StrRef name) const
         {
-            auto iter = std::find_if(m_nodeDecls.begin(), m_nodeDecls.end(), [&](const auto& nodeDecl) {
-                return ((0 == strncmp(nodeDecl.name.str, name.str, name.len)) && (nodeDecl.name.str[name.len] == '\0'));
-            });
+            auto iter = std::find_if(
+                m_nodeDecls.begin(), m_nodeDecls.end(), [&](const auto& nodeDecl) { return (nodeDecl.name == name); });
             return (iter != m_nodeDecls.end()) ? uint32_t(iter - m_nodeDecls.begin()) : RPS_INDEX_NONE_U32;
         }
 

--- a/src/runtime/common/rps_rpsl_host.cpp
+++ b/src/runtime/common/rps_rpsl_host.cpp
@@ -179,9 +179,11 @@ namespace rps
             pResDesc->buffer.sizeInBytesHi = height;
         }
 
-        const uint32_t stableResId =
+        const TResult<uint32_t> stableResId =
             m_pGraphBuilder->GetCurrentProgram()
                 ->m_persistentIndexGenerator.Generate<ProgramInstance::PERSISTENT_INDEX_KIND_RESOURCE_ID>(id);
+
+        RPS_V_RETURN(stableResId.Result());
 
         RPS_V_RETURN(m_pGraphBuilder->DeclareResource(stableResId, pResDesc, {}, pOutResourceId));
 

--- a/src/runtime/common/rps_runtime_backend.cpp
+++ b/src/runtime/common/rps_runtime_backend.cpp
@@ -61,7 +61,7 @@ namespace rps
 
             const bool bIsCreated = resInstance.hRuntimeResource && !resInstance.isPendingCreate;
 
-            if (!resInstance.isExternal && bIsCreated)
+            if (!resInstance.isExternal && bIsCreated && resInstance.isAccessed)
             {
                 resInstance.prevFinalAccess = (bResetAliasedResourceToNoAccess && resInstance.isAliased)
                                                   ? AccessAttr{}

--- a/src/runtime/d3d12/rps_d3d12_barrier.hpp
+++ b/src/runtime/d3d12/rps_d3d12_barrier.hpp
@@ -204,7 +204,7 @@ namespace rps
 
                         RPS_ASSERT(!(resInstance.isAliased && resInstance.IsPersistent()));
 
-                        if (resInstance.hRuntimeResource && !resInstance.isAliased)
+                        if (resInstance.hRuntimeResource && resInstance.isAccessed && !resInstance.isAliased)
                         {
                             for (auto& finalAccess :
                                  resInstance.finalAccesses.Get(context.renderGraph.GetResourceFinalAccesses()))

--- a/src/runtime/d3d12/rps_d3d12_enhanced_barrier.hpp
+++ b/src/runtime/d3d12/rps_d3d12_enhanced_barrier.hpp
@@ -112,7 +112,7 @@ namespace rps
                     {
                         auto& resInstance = resourceInstances[iRes];
 
-                        if (!resInstance.isAliased && resInstance.hRuntimeResource &&
+                        if (resInstance.isAccessed && !resInstance.isAliased && resInstance.hRuntimeResource &&
                             (resInstance.initialAccess.accessFlags != RPS_ACCESS_UNKNOWN))
                         {
                             for (auto& finalAccess :

--- a/src/runtime/d3d12/rps_d3d12_util.hpp
+++ b/src/runtime/d3d12/rps_d3d12_util.hpp
@@ -88,30 +88,6 @@ namespace rps
     static inline RpsResourceFlags D3D12ResourceFlagsToRps(D3D12_RESOURCE_FLAGS flags)
     {
         RpsResourceFlags result = RPS_RESOURCE_FLAG_NONE;
-
-        if (flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
-            result |= RPS_ACCESS_UNORDERED_ACCESS_BIT;
-
-        if (flags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET)
-            result |= RPS_ACCESS_RENDER_TARGET_BIT;
-
-        if (flags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)
-        {
-            result |= RPS_ACCESS_DEPTH_STENCIL;
-
-            if (!(flags & D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE))
-            {
-                result |= RPS_ACCESS_SHADER_RESOURCE_BIT;
-            }
-        }
-
-#if RPS_D3D12_ENHANCED_BARRIER_SUPPORT
-        if (flags & D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE)
-        {
-            result |= (RPS_ACCESS_RAYTRACING_AS_BUILD_BIT | RPS_ACCESS_RAYTRACING_AS_READ_BIT);
-        }
-#endif  //RPS_D3D12_ENHANCED_BARRIER_SUPPORT
-
         return result;
     }
 

--- a/src/runtime/vk/rps_vk_runtime_backend.cpp
+++ b/src/runtime/vk/rps_vk_runtime_backend.cpp
@@ -1498,7 +1498,7 @@ namespace rps
 
                     const bool bResHasMemoryBound = resInstance.hRuntimeResource && !resInstance.isPendingCreate;
 
-                    if (!resInstance.isAliased && bResHasMemoryBound &&
+                    if (resInstance.isAccessed && !resInstance.isAliased && bResHasMemoryBound &&
                         (resInstance.initialAccess.accessFlags != RPS_ACCESS_UNKNOWN))
                     {
                         for (auto& finalAccess :

--- a/tests/gui/test_mrt_viewport_clear_vk.cpp
+++ b/tests/gui/test_mrt_viewport_clear_vk.cpp
@@ -260,8 +260,6 @@ protected:
 
         VkCommandBuffer cmdBuf = rpsVKCommandBufferFromHandle(pContext->hCommandBuffer);
 
-        vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, m_psoBlt);
-
         VkDescriptorSet ds;
         ThrowIfFailedVK(AllocFrameDescriptorSet(&m_descriptorSetLayout, 1, &ds));
 
@@ -363,6 +361,7 @@ protected:
         vkUpdateDescriptorSets(m_device, _countof(writeDescriptorSet), writeDescriptorSet, 0, nullptr);
 
         vkCmdBindDescriptorSets(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelineLayout, 0, 1, &ds, 0, nullptr);
+        vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, m_psoBlt);
         vkCmdDraw(cmdBuf, 3, 1, 0, 0);
     }
 
@@ -391,8 +390,6 @@ protected:
 
         VkCommandBuffer cmdBuf = rpsVKCommandBufferFromHandle(pContext->hCommandBuffer);
 
-        vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, m_psoBltCube);
-
         VkDescriptorSet ds;
         ThrowIfFailedVK(AllocFrameDescriptorSet(&m_descriptorSetLayout, 1, &ds));
 
@@ -404,6 +401,7 @@ protected:
         vkUpdateDescriptorSets(m_device, _countof(writeDescriptorSet), writeDescriptorSet, 0, nullptr);
 
         vkCmdBindDescriptorSets(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelineLayout, 0, 1, &ds, 0, nullptr);
+        vkCmdBindPipeline(cmdBuf, VK_PIPELINE_BIND_POINT_GRAPHICS, m_psoBltCube);
         vkCmdDraw(cmdBuf, 3, 1, 0, 0);
     }
 

--- a/tests/gui/test_multithreading_vk.cpp
+++ b/tests/gui/test_multithreading_vk.cpp
@@ -63,7 +63,7 @@ protected:
             EndCmdList(cl);
         }
 
-        SubmitCmdLists(m_activePrimaryCmdBufs.data(), uint32_t(m_activePrimaryCmdBufs.size()), VK_TRUE);
+        SubmitCmdLists(m_activePrimaryCmdBufs.data(), uint32_t(m_activePrimaryCmdBufs.size()), true);
 
         for (auto& secondaryCmdBuf : m_activeSecondaryCmdBufs)
         {

--- a/tests/gui/test_temporal_vk.cpp
+++ b/tests/gui/test_temporal_vk.cpp
@@ -97,39 +97,7 @@ protected:
 
     virtual void OnRender(uint32_t frameIndex) override
     {
-        RpsRenderGraphBatchLayout batchLayout = {};
-        RpsResult                 result      = rpsRenderGraphGetBatchLayout(m_rpsRenderGraph, &batchLayout);
-        REQUIRE(result == RPS_OK);
-
-        ReserveSemaphores(batchLayout.numFenceSignals);
-
-        for (uint32_t iBatch = 0; iBatch < batchLayout.numCmdBatches; iBatch++)
-        {
-            auto& batch = batchLayout.pCmdBatches[iBatch];
-
-            ActiveCommandList cmdList = BeginCmdList(RPS_AFX_QUEUE_INDEX_GFX);
-
-            RpsRenderGraphRecordCommandInfo recordInfo = {};
-
-            recordInfo.pUserContext  = this;
-            recordInfo.cmdBeginIndex = batch.cmdBegin;
-            recordInfo.numCmds       = batch.numCmds;
-            recordInfo.hCmdBuffer    = rpsVKCommandBufferToHandle(cmdList.cmdBuf);
-
-            result = rpsRenderGraphRecordCommands(m_rpsRenderGraph, &recordInfo);
-            REQUIRE(result == RPS_OK);
-
-            EndCmdList(cmdList);
-
-            SubmitCmdLists(&cmdList,
-                           1,
-                           ((iBatch + 1) == batchLayout.numCmdBatches),
-                           batch.numWaitFences,
-                           batchLayout.pWaitFenceIndices + batch.waitFencesBegin,
-                           batch.signalFenceIndex);
-
-            RecycleCmdList(cmdList);
-        }
+        ExecuteRenderGraph(frameIndex, m_rpsRenderGraph);
     }
 
 private:

--- a/tests/gui/test_triangle_vk.cpp
+++ b/tests/gui/test_triangle_vk.cpp
@@ -137,39 +137,7 @@ protected:
 
         if (useRps)
         {
-            RpsRenderGraphBatchLayout batchLayout = {};
-            RpsResult                 result      = rpsRenderGraphGetBatchLayout(m_rpsRenderGraph, &batchLayout);
-            REQUIRE(result == RPS_OK);
-
-            ReserveSemaphores(batchLayout.numFenceSignals);
-
-            for (uint32_t iBatch = 0; iBatch < batchLayout.numCmdBatches; iBatch++)
-            {
-                auto& batch = batchLayout.pCmdBatches[iBatch];
-
-                ActiveCommandList cmdList = BeginCmdList(RPS_AFX_QUEUE_INDEX_GFX);
-
-                RpsRenderGraphRecordCommandInfo recordInfo = {};
-
-                recordInfo.pUserContext  = this;
-                recordInfo.cmdBeginIndex = batch.cmdBegin;
-                recordInfo.numCmds       = batch.numCmds;
-                recordInfo.hCmdBuffer    = rpsVKCommandBufferToHandle(cmdList.cmdBuf);
-
-                result = rpsRenderGraphRecordCommands(m_rpsRenderGraph, &recordInfo);
-                REQUIRE(result == RPS_OK);
-
-                EndCmdList(cmdList);
-
-                SubmitCmdLists(&cmdList,
-                               1,
-                               ((iBatch + 1) == batchLayout.numCmdBatches),
-                               batch.numWaitFences,
-                               batchLayout.pWaitFenceIndices + batch.waitFencesBegin,
-                               batch.signalFenceIndex);
-
-                RecycleCmdList(cmdList);
-            }
+            ExecuteRenderGraph(frameIndex, m_rpsRenderGraph);
         }
         else
         {
@@ -179,7 +147,7 @@ protected:
 
             EndCmdList(cmdList);
 
-            SubmitCmdLists(&cmdList, 1, VK_TRUE);
+            SubmitCmdLists(&cmdList, 1, true);
 
             RecycleCmdList(cmdList);
         }

--- a/tools/rps_visualizer/src/rps_visualizer.cpp
+++ b/tools/rps_visualizer/src/rps_visualizer.cpp
@@ -172,12 +172,15 @@ namespace rps
             const size_t timelineMax           = m_timelinePosToCmdIdMap.size();
             const bool   bLifetimeBeginDefined = (resInfo.lifetimeBegin != ResourceInstance::LIFETIME_UNDEFINED);
             const bool   bLifetimeEndDefined   = (resInfo.lifetimeEnd != ResourceInstance::LIFETIME_UNDEFINED);
+            const bool   bHasAnyCmdVisInfo     = !cmdVisInfos.empty();
 
             if (resInfo.lifetimeBegin <= resInfo.lifetimeEnd)
             {
                 resourceVisInfos[iRes] = ResourceVisualizationInfo(
-                    bLifetimeBeginDefined ? cmdVisInfos[resInfo.lifetimeBegin].timelinePosition : 0,
-                    bLifetimeEndDefined ? cmdVisInfos[resInfo.lifetimeEnd].timelinePosition : uint32_t(timelineMax),
+                    (bLifetimeBeginDefined && bHasAnyCmdVisInfo) ? cmdVisInfos[resInfo.lifetimeBegin].timelinePosition
+                                                                 : 0,
+                    (bLifetimeEndDefined && bHasAnyCmdVisInfo) ? cmdVisInfos[resInfo.lifetimeEnd].timelinePosition
+                                                               : uint32_t(timelineMax),
                     pRenderGraph->GetResourceInstance(iRes).isAliased);
             }
         }


### PR DESCRIPTION
- Remove some incorrect flags in D3D12ResourceFlagsToRps.
- Allow non zero-terminated strings to be used as NodeDecl name.
- Allow multiple compatible access flags on the same subresource by the same node.
- Fix some missing and incorrect return code checks.
- Fix incorrect cmd range when printing cmd batches in ScheduleDebugPrintPhase.
- Avoid transitioning unaccessed persistent resources by marking them unaccessed. This caused barriers on currently presenting swapchain images.
- Fix crash in visualizer when graph is empty.
- Fix various validation errors with SDK 1.3.275.